### PR TITLE
feat: add `--eslint-config` option to run-single command

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -27,14 +27,14 @@ interface RunSingleCommandOptions {
    */
   report: ReporterFormat
 
+  /** Optional path to an ESLint configuration file to use for linting. */
+  eslintConfig?: string
+
   /** Maximum allowed duration in ms. */
   maxDuration: number
 
   /** The number of iterations to run the benchmark for the rule. */
   iterations: number
-
-  /** Optional path to an ESLint configuration file to use for linting. */
-  config?: string
 
   /** Optional path to a file where the benchmark report should be saved. */
   output?: string
@@ -150,7 +150,7 @@ export function run(): void {
     .command('run-single', 'Run benchmark on a single ESLint rule')
     .option('--rule <rule>', 'Path to the ESLint rule file')
     .option('--name <name>', 'Name of the rule to benchmark')
-    .option('--config <config>', 'Path to ESLint config file')
+    .option('--eslint-config <config>', 'Path to ESLint config file')
     .option('--source <source>', 'Path to directory or file with test cases')
     .option('--iterations <number>', 'Number of benchmark iterations', {
       default: DEFAULT_ITERATIONS,
@@ -227,6 +227,7 @@ export function run(): void {
         console.info(`Using source: ${options.source}`)
 
         await runBenchmarksFromConfig({
+          eslintConfigFile: options.eslintConfig,
           reporterOptions: reporterOptionsArray,
           userConfig: constructedUserConfig,
           configDirectory,

--- a/core/benchmark/run-benchmark.ts
+++ b/core/benchmark/run-benchmark.ts
@@ -21,6 +21,9 @@ export interface ProcessedBenchmarkTask {
 
 /** Parameters for running a benchmark. */
 interface RunBenchmarkParameters {
+  /** Optional path to custom ESLint config file. */
+  eslintConfigFile?: string
+
   /** Configuration for the benchmark. */
   config: BenchmarkConfig
 
@@ -69,7 +72,7 @@ type Language = (typeof LANGUAGES)[number]
 export async function runBenchmark(
   parameters: RunBenchmarkParameters,
 ): Promise<ProcessedBenchmarkTask[] | null> {
-  let { configDirectory, testCases, config } = parameters
+  let { eslintConfigFile, configDirectory, testCases, config } = parameters
 
   if (testCases.length === 0) {
     return null
@@ -103,6 +106,7 @@ export async function runBenchmark(
       eslint = await createESLintInstance({
         languages: currentTestCaseLanguages,
         rule: testCase.rule,
+        eslintConfigFile,
         configDirectory,
       })
       await eslint.lintText('/* eslint-disable */')

--- a/core/eslint/create-eslint-instance.ts
+++ b/core/eslint/create-eslint-instance.ts
@@ -12,6 +12,9 @@ import { toSeverity } from './to-severity'
 
 /** Options for creating an ESLint instance. */
 interface CreateESLintInstanceOptions {
+  /** Optional path to custom ESLint config file. */
+  eslintConfigFile?: string
+
   /** The path to the user configuration directory. */
   configDirectory: string
 
@@ -45,7 +48,7 @@ let jiti = createJiti(import.meta.url, {
 export async function createESLintInstance(
   instanceOptions: CreateESLintInstanceOptions,
 ): Promise<ESLint> {
-  let { configDirectory, languages, rule } = instanceOptions
+  let { eslintConfigFile, configDirectory, languages, rule } = instanceOptions
 
   let { path: rulePath, severity, options, ruleId } = rule
 
@@ -140,8 +143,8 @@ export async function createESLintInstance(
 
   return new FlatESLint({
     ruleFilter: ({ ruleId: currentRuleId }) => currentRuleId === uniqueRuleId,
+    overrideConfigFile: eslintConfigFile ?? null,
     overrideConfig: [flatConfig],
-    overrideConfigFile: null,
     allowInlineConfig: false,
     fix: true,
   })

--- a/runners/run-benchmarks-from-config.ts
+++ b/runners/run-benchmarks-from-config.ts
@@ -33,6 +33,9 @@ interface RunBenchmarksFromConfigParameters {
   /** The user-defined benchmark configuration. */
   userConfig: UserBenchmarkConfig
 
+  /** Optional path to custom ESLint config file. */
+  eslintConfigFile?: string
+
   /** User configuration directory path */
   configDirectory: string
 }
@@ -89,7 +92,8 @@ interface RunBenchmarksFromConfigParameters {
 export async function runBenchmarksFromConfig(
   parameters: RunBenchmarksFromConfigParameters,
 ): Promise<void> {
-  let { reporterOptions, configDirectory, userConfig } = parameters
+  let { eslintConfigFile, reporterOptions, configDirectory, userConfig } =
+    parameters
 
   if (userConfig.tests.length === 0) {
     console.warn('User configuration contains no tests. Exiting.')
@@ -173,6 +177,7 @@ export async function runBenchmarksFromConfig(
         // eslint-disable-next-line no-await-in-loop
         await runBenchmark({
           config: specBenchmarkConfig,
+          eslintConfigFile,
           configDirectory,
           testCases,
         })

--- a/test/core/eslint/create-eslint-instance.test.ts
+++ b/test/core/eslint/create-eslint-instance.test.ts
@@ -483,4 +483,19 @@ describe('createESLintInstance', () => {
 
     expect(config.rules).toBeDefined()
   })
+
+  it('sets custom config file when provided', async () => {
+    constructorOptions = {}
+
+    await createESLintInstance({
+      eslintConfigFile: '/path/to/custom/eslint.config.js',
+      rule: { ruleId: 'test-rule', severity: 2 },
+      configDirectory: temporaryDirectory,
+      languages: ['javascript'],
+    })
+
+    expect(constructorOptions['overrideConfigFile']).toBe(
+      '/path/to/custom/eslint.config.js',
+    )
+  })
 })


### PR DESCRIPTION
Implements the `--eslint-config` option for the `run-single` command to support custom ESLint configurations.

Note: I have renamed the cli command from `config` to `eslint-config`. This is because the `run` command has a --config flag that acts differently (it expects the benchmark config). I thought it was more appropriate to differentiate the two as they serve difference purposes.

I am happy to revert this change if desired.

**Changes:**
- Add `--eslint-config` CLI option
- Pass ESLint config through the execution chain to `createESLintInstance`
- Add test coverage for new functionality

```bash
eslint-rule-benchmark run-single --rule rule.js --name test --source test.jsx --eslint-config eslint.config.mjs
```

Fixes #3

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-rule-benchmark/blob/main/contributing.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom ESLint configuration file when running single rule benchmarks via a new `--eslint-config` CLI option.

* **Bug Fixes**
  * Ensured the correct propagation and usage of the custom ESLint configuration file throughout the benchmarking process.

* **Tests**
  * Added a test to verify that the custom ESLint configuration file is correctly applied when creating an ESLint instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->