### PR TITLE
feat: lint all supported extensions by default

### DIFF
--- a/core/eslint/create-eslint-instance.ts
+++ b/core/eslint/create-eslint-instance.ts
@@ -8,6 +8,7 @@ import type { LANGUAGES } from '../../constants'
 
 import { loadLanguageParser } from './load-language-parser'
 import { loadRuleFromFile } from './load-rule-from-file'
+import { SUPPORTED_EXTENSIONS } from '../../constants'
 import { toSeverity } from './to-severity'
 
 /** Options for creating an ESLint instance. */
@@ -127,6 +128,7 @@ export async function createESLintInstance(
   }
 
   let flatConfig: Linter.Config = {
+    files: SUPPORTED_EXTENSIONS.map(extension => `**/*.${extension}`),
     rules: {
       [uniqueRuleId]: ruleEntry,
     },


### PR DESCRIPTION
This PR fixes JSX (and other supported extension) files not being supported by default, ensuring they are properly linted during benchmarks instead of being ignored.

This provides out-of-the-box JSX support without requiring custom ESLint configurations or CLI workarounds.

**Note:** This PR is opened as a draft because I attempted to write tests for this change but wasn't sure how to properly test the ESLint instance creation with the `files` property. Guidance on the testing approach would be appreciated.

Closes #5

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is
  solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with
  it.
- [x] Read [contribution
  guidelines](https://github.com/azat-io/eslint-rule-benchmark/blob/main/contributing.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ESLint configuration now explicitly targets only files with supported extensions, improving accuracy of linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->